### PR TITLE
Add package requirement for bs4

### DIFF
--- a/custom_components/poolmath/manifest.json
+++ b/custom_components/poolmath/manifest.json
@@ -2,7 +2,7 @@
   "domain": "poolmath",
   "name": "Pool Math by Trouble Free Pool",
   "documentation": "https://github.com/rsnodgrass/hass-poolmath/",
-  "requirements": [],
+  "requirements": ["beautifulsoup4==4.9.0"],
   "dependencies": [],
   "codeowners": ["@rsnodgrass"]
 }

--- a/custom_components/poolmath/manifest.json
+++ b/custom_components/poolmath/manifest.json
@@ -2,7 +2,7 @@
   "domain": "poolmath",
   "name": "Pool Math by Trouble Free Pool",
   "documentation": "https://github.com/rsnodgrass/hass-poolmath/",
-  "requirements": ["beautifulsoup4==4.9.0"],
+  "requirements": ["beautifulsoup4==4.9.0", "jsonpath==0.82"],
   "dependencies": [],
   "codeowners": ["@rsnodgrass"]
 }

--- a/custom_components/poolmath/manifest.json
+++ b/custom_components/poolmath/manifest.json
@@ -2,7 +2,11 @@
   "domain": "poolmath",
   "name": "Pool Math by Trouble Free Pool",
   "documentation": "https://github.com/rsnodgrass/hass-poolmath/",
-  "requirements": ["beautifulsoup4==4.9.0", "jsonpath==0.82"],
+  "requirements": [
+    "beautifulsoup4==4.9.0", 
+    "jsonpath==0.82",
+    "xmltodict==0.12.0"
+  ],
   "dependencies": [],
   "codeowners": ["@rsnodgrass"]
 }

--- a/custom_components/poolmath/sensor.py
+++ b/custom_components/poolmath/sensor.py
@@ -2,7 +2,7 @@ import logging
 
 import voluptuous as vol
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
-from bs4 import BeautifulSoup
+from beautifulsoup4 import BeautifulSoup
 from datetime import timedelta
 
 from homeassistant.core import callback

--- a/custom_components/poolmath/sensor.py
+++ b/custom_components/poolmath/sensor.py
@@ -2,7 +2,7 @@ import logging
 
 import voluptuous as vol
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
-from beautifulsoup4 import BeautifulSoup
+from bs4 import BeautifulSoup
 from datetime import timedelta
 
 from homeassistant.core import callback


### PR DESCRIPTION
bs4 was apparently removed from HA core in v0.115

This change resolves the missing package error after installing the latest core release