### PR TITLE
Remove blocking call in async_update

### DIFF
--- a/custom_components/poolmath/client.py
+++ b/custom_components/poolmath/client.py
@@ -65,7 +65,7 @@ class PoolMathClient:
             except aiohttp.ClientError as e:
                 LOG.error(f"Error fetching data from PoolMath API: {e}")
                 return None
-            
+
     async def process_log_entry_callbacks(self, poolmath_json, async_callback):
         """Call provided async callback once for each type of log entry"""
         """   async_callback(measurement_type, timestamp, state, attributes)"""


### PR DESCRIPTION
My HA instance (v2024.10.1) lists a warning for the PoolMath integration that a blocking call was detected in `client.py`'s `async_update` on line 73.

This PR updates the `async_update` function to use non-blocking I/O when fetching data from the PoolMath API, using the `aiohttp` library described in the HA dev docs.

Tested on 2024.10.1 and confirmed HA no longer logs this warning when `async_update` is called.

Happy to rebase if #30 is merged first!