### PR TITLE
Use newer PoolMath API

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,17 +50,19 @@ Make sure [Home Assistant Community Store (HACS)](https://github.com/custom-comp
 
 ### Configuration
 
-Under Settings of the Pool Math iOS or Android application, find the Sharing section.  Turn this on, which allows anyone with access to the unique URL to be able to view data about your pool. Your pool's URL will be displayed. The Share ID from the URL will be used to configure the poolmath service.
+Under Settings of the Pool Math iOS or Android application, find the Sharing section.  Turn this on (and be sure to save the changes too), which allows anyone with access to the unique URL to be able to view data about your pool. Your pool's URL will be displayed.  You will need this URL to determine your `userId` and `poolId` configuration values for this component.
 
-Example URL: `https://troublefreepool.com/mypool/7WPG8yL`
+Take the generated URL and modify it to add `.json` to the end of it.  Enter the URL in your browser or curl or some client to see the JSON output.  
 
-Example Share ID: `7WPG8yL`
+Example URL: `https://troublefreepool.com/mypool/7WPG8yL.json`
 
-Configure `Pool Math (Trouble Free Pool)` via integrations page or press the blue button below.
+From the JSON output, you will need to find the values for the `id` and `userId` properties.  Your userId will start with `tfp-` if you are using a TroubleFreePool forum account in the app, or `google-` / `facebook-` / `apple-` if you use those sign in providers.  Your `id` (poolId) will be a longer GUID string.
+
+Configure `Pool Math (Trouble Free Pool)` via integrations page or press the blue button below, filling in the `userId` and `poolId` you determined from the JSON.
 
 [![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=poolmath)
 
-NOTE: This updates the state from PoolMath every 2 minutes to keep from overwhelming their service, as the majority of Pool Math users update their data manual after testing rather than automated. The check interval can be changed in yaml config by adding a 'scan_interval' for the sensor.
+NOTE: This updates the state from PoolMath every 8 minutes (results are cached for 10 minutes already, and requests are rate limited to no more than once per minute) to keep from overwhelming their service, as the majority of Pool Math users update their data manual after testing rather than automated. The check interval can be changed in yaml config by adding a 'scan_interval' for the sensor.
 
 ### Example Lovelace UI
 
@@ -130,9 +132,9 @@ type: entities
 ```yaml
 poolmath:
   sources:
-    - url: https://api.poolmathapp.com/share/AbC123.json
+    - url: https://api.poolmathapp.com/share/?userId=[USER_ID]&poolId=[POOL_ID]
       name: "Swimming Pool"
-    - url: https://api.poolmathapp.com/share/7WPG8yL.json
+    - url: https://api.poolmathapp.com/share/?userId=[USER_ID]&poolId=[POOL_ID]
       name: "Spa"
 ```
 

--- a/custom_components/poolmath/__init__.py
+++ b/custom_components/poolmath/__init__.py
@@ -7,7 +7,7 @@ from homeassistant.const import CONF_NAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import CONF_SHARE_ID, CONF_TARGET, CONF_TIMEOUT, DOMAIN
+from .const import CONF_USER_ID, CONF_POOL_ID, CONF_TARGET, CONF_TIMEOUT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -16,7 +16,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Pool Math from a config entry."""
 
     # prefer options
-    share_id = entry.options.get(CONF_SHARE_ID, entry.data[CONF_SHARE_ID])
+    user_id = entry.options.get(CONF_USER_ID, entry.data[CONF_USER_ID])
+    pool_id = entry.options.get(CONF_POOL_ID, entry.data[CONF_POOL_ID])
     name = entry.options.get(CONF_NAME, entry.data[CONF_NAME])
     timeout = entry.options.get(CONF_TIMEOUT, entry.data[CONF_TIMEOUT])
     target = entry.options.get(CONF_TARGET, entry.data[CONF_TARGET])
@@ -25,7 +26,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.config_entries.async_update_entry(
         entry,
         options={
-            CONF_SHARE_ID: share_id,
+            CONF_USER_ID: user_id,
+            CONF_POOL_ID: pool_id,
             CONF_NAME: name,
             CONF_TIMEOUT: timeout,
             CONF_TARGET: target,

--- a/custom_components/poolmath/client.py
+++ b/custom_components/poolmath/client.py
@@ -38,11 +38,12 @@ ONLY_INCLUDE_IF_TRACKED = {
 
 
 class PoolMathClient:
-    def __init__(self, share_id: str, name=DEFAULT_NAME, timeout=DEFAULT_TIMEOUT):
-        self._share_id = share_id
+    def __init__(self, user_id: str, pool_id: str, name=DEFAULT_NAME, timeout=DEFAULT_TIMEOUT):
+        self._user_id = user_id
+        self._pool_id = pool_id
         self._name = name
         self._timeout = timeout
-        self._json_url = f"https://api.poolmathapp.com/share/{self._share_id}.json"
+        self._json_url = f"https://api.poolmathapp.com/share/?userId={self._user_id}&poolId={self._pool_id}"
         LOG.debug(f"Using JSON URL: {self._json_url}")
 
     async def async_update(self):
@@ -51,7 +52,7 @@ class PoolMathClient:
         async with aiohttp.ClientSession() as session:
             try:
                 LOG.info(
-                    f"GET {self._json_url} (timeout={self._timeout}; name={self._name}; id={self._share_id})"
+                    f"GET {self._json_url} (timeout={self._timeout}; name={self._name}; user_id={self._user_id}; pool_id={self._pool_id})"
                 )
                 async with session.get(self._json_url, timeout=self._timeout) as response:
                     LOG.debug(f"GET {self._json_url} response: {response.status}")
@@ -130,11 +131,11 @@ class PoolMathClient:
         return latest_timestamp
     @property
     def pool_id(self):
-        return self._share_id
+        return self._pool_id
 
     @property
-    def share_id(self):
-        return self._share_id
+    def user_id(self):
+        return self._user_id
 
     @property
     def name(self):

--- a/custom_components/poolmath/config_flow.py
+++ b/custom_components/poolmath/config_flow.py
@@ -16,7 +16,8 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv
 
 from .const import (
-    CONF_SHARE_ID,
+    CONF_USER_ID,
+    CONF_POOL_ID,
     CONF_TARGET,
     CONF_TIMEOUT,
     DEFAULT_NAME,
@@ -34,13 +35,15 @@ def _initial_form(flow: Union[ConfigFlow, OptionsFlow]):
 
     if isinstance(flow, ConfigFlow):
         step_id = "user"
-        share_id = None
+        user_id = None
+        pool_id = None
         name = DEFAULT_NAME
         timeout = DEFAULT_TIMEOUT
         target = DEFAULT_TARGET
     elif isinstance(flow, OptionsFlow):
         step_id = "init"
-        share_id = flow.config_entry.options.get(CONF_SHARE_ID)
+        user_id = flow.config_entry.options.get(CONF_USER_ID)
+        pool_id = flow.config_entry.options.get(CONF_POOL_ID)
         name = flow.config_entry.options.get(CONF_NAME, DEFAULT_NAME)
         timeout = flow.config_entry.options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
         target = flow.config_entry.options.get(CONF_TARGET, DEFAULT_TARGET)
@@ -51,7 +54,8 @@ def _initial_form(flow: Union[ConfigFlow, OptionsFlow]):
         step_id=step_id,  # parameterized to follow guidance on using "user"
         data_schema=vol.Schema(
             {
-                vol.Required(CONF_SHARE_ID, default=share_id): cv.string,
+                vol.Required(CONF_USER_ID, default=user_id): cv.string,
+                vol.Required(CONF_POOL_ID, default=pool_id): cv.string,
                 vol.Optional(CONF_NAME, default=name): cv.string,
                 vol.Optional(CONF_TIMEOUT, default=timeout): cv.positive_int,
                 # NOTE: targets are not really implemented, other than tfp
@@ -89,9 +93,10 @@ class PoolMathFlowHandler(ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None) -> FlowResult:
         """Handle the initial step."""
         if user_input is not None:
-            # already configured share_id?
-            share_id = user_input.get(CONF_SHARE_ID)
-            await self.async_set_unique_id(share_id)
+            # already configured user_id and pool_id?
+            user_id = user_input.get(CONF_USER_ID)
+            pool_id = user_input.get(CONF_POOL_ID)
+            await self.async_set_unique_id(user_id + "-" + pool_id)
             self._abort_if_unique_id_configured()
 
             return self.async_create_entry(title=INTEGRATION_NAME, data=user_input)

--- a/custom_components/poolmath/const.py
+++ b/custom_components/poolmath/const.py
@@ -11,7 +11,8 @@ ATTR_TARGET_MIN = "target_min"
 ATTR_TARGET_MAX = "target_max"
 ATTR_TARGET_SOURCE = "target_source"
 
-CONF_SHARE_ID = "share_id"
+CONF_USER_ID = "user_id"
+CONF_POOL_ID = "pool_id"
 CONF_TARGET = "target"
 CONF_TIMEOUT = "timeout"
 

--- a/custom_components/poolmath/sensor.py
+++ b/custom_components/poolmath/sensor.py
@@ -22,7 +22,8 @@ from .const import (
     ATTR_LAST_UPDATED_TIME,
     ATTR_TARGET_SOURCE,
     ATTRIBUTION,
-    CONF_SHARE_ID,
+    CONF_USER_ID,
+    CONF_POOL_ID,
     CONF_TARGET,
     CONF_TIMEOUT,
     DOMAIN,
@@ -34,7 +35,7 @@ LOG = logging.getLogger(__name__)
 
 DATA_UPDATED = "poolmath_data_updated"
 
-SCAN_INTERVAL = timedelta(minutes=2)
+SCAN_INTERVAL = timedelta(minutes=8)
 
 
 async def async_setup_entry(
@@ -44,13 +45,14 @@ async def async_setup_entry(
 ) -> None:
     """Set up Pool Math sensor based on a config entry."""
 
-    share_id = entry.options[CONF_SHARE_ID]
+    user_id = entry.options[CONF_USER_ID]
+    pool_id = entry.options[CONF_POOL_ID]
     name = entry.options[CONF_NAME]
     timeout = entry.options[CONF_TIMEOUT]
     target = entry.options[CONF_TARGET]
     # log_types = entry.options[CONF_LOG_TYPES]
 
-    client = PoolMathClient(share_id, name=name, timeout=timeout)
+    client = PoolMathClient(user_id, pool_id, name=name, timeout=timeout)
 
     # create the core Pool Math service sensor, which is responsible for updating all other sensors
     sensor = PoolMathServiceSensor(hass, entry, name, client, async_add_entities)

--- a/custom_components/poolmath/strings.json
+++ b/custom_components/poolmath/strings.json
@@ -4,7 +4,8 @@
       "user": {
         "description": "Connect to Pool Math",
         "data": {
-          "share_id": "[%key:common::config_flow::data::share_id%]",
+          "user_id": "[%key:common::config_flow::data::user_id%]",
+          "pool_id": "[%key:common::config_flow::data::pool_id%]",
           "name": "[%key:common::config_flow::data::name%]",
           "timeout": "[%key:common::config_flow::data::timeout%]",
           "target": "[%key:common::config_flow::data::target%]"
@@ -24,7 +25,8 @@
     "step": {
       "init": {
         "data": {
-          "share_id": "[%key:common::config_flow::data::share_id%]",
+          "user_id": "[%key:common::config_flow::data::user_id%]",
+          "pool_id": "[%key:common::config_flow::data::pool_id%]",
           "name": "[%key:common::config_flow::data::name%]",
           "timeout": "[%key:common::config_flow::data::timeout%]",
           "target": "[%key:common::config_flow::data::target%]"

--- a/custom_components/poolmath/translations/en.json
+++ b/custom_components/poolmath/translations/en.json
@@ -4,7 +4,8 @@
       "user": {
         "description": "Connect to Pool Math",
         "data": {
-          "share_id": "Share ID from PoolMath Share URL",
+          "user_id": "User ID from PoolMath Share URL JSON Results",
+          "pool_id": "Pool ID from PoolMath Share URL JSON Results",
           "name": "Pool Name",
           "timeout": "Update timeout",
           "target": "Target levels source"
@@ -24,7 +25,8 @@
     "step": {
       "init": {
         "data": {
-          "share_id": "Share ID from PoolMath Share URL",
+          "User_id": "User ID ID from PoolMath Share URL JSON Results",
+          "pool_id": "Pool ID from PoolMath Share URL JSON Results",
           "name": "Pool Name",
           "timeout": "Update timeout",
           "target": "Target levels source"

--- a/custom_components/poolmath/translations/sk.json
+++ b/custom_components/poolmath/translations/sk.json
@@ -4,7 +4,8 @@
       "user": {
         "description": "Pripojiť k Pool Math",
         "data": {
-          "share_id": "ID zdieľania z adresy URL zdieľania PoolMath",
+          "user_id": "ID používateľa z JSON výsledkov PoolMath zdieľaného URL",
+          "pool_id": "ID bazéna z JSON výsledkov PoolMath zdieľaného URL",
           "name": "Pool názov",
           "timeout": "Časový limit aktualizácie",
           "target": "Zdroj cieľových úrovní"
@@ -24,7 +25,8 @@
     "step": {
       "init": {
         "data": {
-          "share_id": "ID zdieľania z adresy URL zdieľania PoolMath",
+          "user_id": "ID zdieľania z adresy URL zdieľania PoolMath",
+          "pool_id": "ID bazéna z JSON výsledkov PoolMath zdieľaného URL",
           "name": "Pool názov",
           "timeout": "Časový limit aktualizácie",
           "target": "Zdroj cieľových úrovní"


### PR DESCRIPTION
Follow up from: https://community.home-assistant.io/t/custom-component-pool-math-sensors-for-pool-chemicals-and-operations/435126/37?u=redth

The newer PoolMath API helps minimize the impact of API calls on the backend server.  It also helps with reliability as it uses the `poolId` which is more stable than the share code.

Also increased the interval to 8 minutes by default since the service caches the data for 10 minutes anyway.