### PR TITLE
Added Create Issue / Repair flow to simplify migration.

### DIFF
--- a/custom_components/poolmath/client.py
+++ b/custom_components/poolmath/client.py
@@ -43,7 +43,7 @@ class PoolMathClient:
         self._pool_id = pool_id
         self._name = name
         self._timeout = timeout
-        self._json_url = f"https://api.poolmathapp.com/share/?userId={self._user_id}&poolId={self._pool_id}"
+        self._json_url = f"https://api.poolmathapp.com/share/pool?userId={self._user_id}&poolId={self._pool_id}"
         LOG.debug(f"Using JSON URL: {self._json_url}")
 
     async def async_update(self):

--- a/custom_components/poolmath/const.py
+++ b/custom_components/poolmath/const.py
@@ -13,6 +13,8 @@ ATTR_TARGET_SOURCE = "target_source"
 
 CONF_USER_ID = "user_id"
 CONF_POOL_ID = "pool_id"
+CONF_SHARE_ID = "share_id"  # Old configuration key
+CONF_SHARE_URL = "share_url"  # Share URL for simple setup
 CONF_TARGET = "target"
 CONF_TIMEOUT = "timeout"
 

--- a/custom_components/poolmath/manifest.json
+++ b/custom_components/poolmath/manifest.json
@@ -14,5 +14,8 @@
     "jsonpath>=0.82",
     "httpx>=0.16.1"
   ],
-  "version": "2.0.0"
+  "version": "2.0.0",
+  "repairs": [
+    "repairs"
+  ]
 }

--- a/custom_components/poolmath/repairs.py
+++ b/custom_components/poolmath/repairs.py
@@ -1,0 +1,127 @@
+"""Repair handler for Pool Math integration."""
+import logging
+import re
+import aiohttp
+import voluptuous as vol
+
+from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.issue_registry import async_delete_issue
+
+from .const import (
+    CONF_USER_ID,
+    CONF_POOL_ID,
+    DOMAIN,
+    INTEGRATION_NAME,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_SHARE_URL = "share_url"
+
+URL_PATTERN = r"https://(?:api\.poolmathapp\.com|troublefreepool\.com)/(?:share/|mypool/)([a-zA-Z0-9]+)"
+
+class PoolMathRepairFlow(RepairsFlow):
+    """Handler for an issue fixing flow."""
+    
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialize the repair flow."""
+        super().__init__()
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None) -> FlowResult:
+        """Handle the first step of a fix flow."""
+        return await self.async_step_share_url()
+
+    async def async_step_share_url(self, user_input=None) -> FlowResult:
+        """Ask for the share URL to extract user_id and pool_id."""
+        if user_input is not None:
+            share_url = user_input[CONF_SHARE_URL]
+            
+            # Extract the share_id from the URL
+            match = re.search(URL_PATTERN, share_url)
+            if not match:
+                return self.async_show_form(
+                    step_id="share_url",
+                    data_schema=vol.Schema({
+                        vol.Required(CONF_SHARE_URL): cv.string,
+                    }),
+                    errors={"base": "invalid_url"},
+                )
+            
+            share_id = match.group(1)
+            
+            # Fetch the JSON data to extract user_id and pool_id
+            json_url = f"https://api.poolmathapp.com/share/{share_id}.json"
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.get(json_url, timeout=10) as response:
+                        if response.status != 200:
+                            _LOGGER.error(f"Error: Received status code {response.status} from API")
+                            return self.async_show_form(
+                                step_id="share_url",
+                                data_schema=vol.Schema({
+                                    vol.Required(CONF_SHARE_URL): cv.string,
+                                }),
+                                errors={"base": "api_error"},
+                            )
+                        data = await response.json()
+                        
+                        # Extract the pool data
+                        pool = next(iter(data.get("pools", [])), {}).get("pool", {})
+                        
+                        # Get the user_id from the pool data
+                        user_id = pool.get("userId")
+                            
+                        # Get the pool_id from the pool data
+                        pool_id = pool.get("id")
+                        
+                        _LOGGER.debug(f"Extracted user_id: {user_id}, pool_id: {pool_id}")
+                        
+                        if not user_id or not pool_id:
+                            _LOGGER.error(f"Missing data in API response: user_id={user_id}, pool_id={pool_id}")
+                            _LOGGER.debug(f"API response data: {data}")
+                            return self.async_show_form(
+                                step_id="share_url",
+                                data_schema=vol.Schema({
+                                    vol.Required(CONF_SHARE_URL): cv.string,
+                                }),
+                                errors={"base": "missing_data"},
+                            )
+                        
+                        # Update the config entry with the new data
+                        new_data = dict(self.config_entry.data)
+                        new_data[CONF_USER_ID] = user_id
+                        new_data[CONF_POOL_ID] = pool_id
+                        
+                        self.hass.config_entries.async_update_entry(
+                            self.config_entry, data=new_data
+                        )
+                        
+                        return self.async_create_entry(title="", data={})
+            except Exception as exc:
+                _LOGGER.exception("Error fetching data from Pool Math API: %s", exc)
+                return self.async_show_form(
+                    step_id="share_url",
+                    data_schema=vol.Schema({
+                        vol.Required(CONF_SHARE_URL): cv.string,
+                    }),
+                    errors={"base": "unknown"},
+                )
+        
+        return self.async_show_form(
+            step_id="share_url",
+            data_schema=vol.Schema({
+                vol.Required(CONF_SHARE_URL): cv.string,
+            }),
+        )
+
+async def async_create_fix_flow(
+    hass: HomeAssistant, issue_id: str, data: dict
+) -> RepairsFlow:
+    """Create flow to fix an issue."""
+    if issue_id == "config_migration_needed":
+        return PoolMathRepairFlow(data["config_entry"])

--- a/custom_components/poolmath/strings.json
+++ b/custom_components/poolmath/strings.json
@@ -21,6 +21,32 @@
       "already_configured": "Device is already configured"
     }
   },
+  "issues": {
+    "config_migration_needed": {
+      "title": "Pool Math configuration needs to be updated",
+      "fix_flow": {
+        "step": {
+          "share_url": {
+            "title": "Update Pool Math configuration",
+            "description": "Please enter your Pool Math Share URL to update your configuration from share_id to user_id and pool_id.",
+            "data": {
+              "share_url": "Pool Math Share URL"
+            }
+          }
+        },
+        "abort": {
+          "not_supported": "This issue fix is not supported",
+          "already_fixed": "Configuration has already been updated"
+        },
+        "error": {
+          "invalid_url": "Invalid Pool Math share URL",
+          "api_error": "Error connecting to Pool Math API",
+          "missing_data": "Could not extract user_id or pool_id from the API response",
+          "unknown": "Unexpected error occurred"
+        }
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/poolmath/translations/en.json
+++ b/custom_components/poolmath/translations/en.json
@@ -33,5 +33,32 @@
         }
       }
     }
+  },
+  "issues": {
+    "config_migration_needed": {
+      "title": "Pool Math: Configuration Update Required",
+      "description": "The Pool Math integration has been updated and now requires a user_id and pool_id instead of a share_id. Please submit a repair to update your configuration.",
+      "fix_flow": {
+        "step": {
+          "share_url": {
+            "title": "Update Pool Math Configuration",
+            "description": "Please paste your Pool Math share URL from the Pool Math app. You can find this under Settings > Sharing. The URL should look like: https://api.poolmathapp.com/share/XXXXXXX or https://troublefreepool.com/mypool/XXXXXXX.",
+            "data": {
+              "share_url": "Pool Math Share URL"
+            }
+          }
+        },
+        "abort": {
+          "not_supported": "This issue fix is not supported",
+          "already_fixed": "Configuration has already been updated"
+        },
+        "error": {
+          "invalid_url": "The provided URL is not a valid Pool Math share URL.",
+          "api_error": "Failed to connect to the Pool Math service. Please check the URL and try again.",
+          "missing_data": "Could not extract the required data from the API response.",
+          "unknown": "An unexpected error occurred. Please check the logs for more details."
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This builds upon the changes in #35. 

While testing that out, I ran into the following error, which was probably expected:

![Error after upgrade](https://github.com/user-attachments/assets/f82c610b-3c29-41bb-b290-be6b8154a706)

Since I use the Pool Math app on my phone, the process for getting the new ID's required jumping between devices was cumbersome, and I thought I could make it simpler. Ideally, we could just paste in the Share Url directly from the app and let it get the configuration data it needs.

This PR introduces a migration mechanism to transition from using `share_id` to `user_id` and `pool_id` for configuration. It includes a new repair flow to guide users through updating their configuration, along with updates to the API handling code and translations.

### Migration and Repair Flow:

* Added a repair handler in `repairs.py` to assist users in migrating their configuration by extracting `user_id` and `pool_id` from a `share_url`. This includes validation, API calls, and updating the configuration entry. I mainly did this because I didn't want to uninstall and reinstall just to update the configuration.
* Updated `__init__.py` to detect the deprecated configurations using `share_id` and create a repair issue if migration is needed.
![Repair Issue](https://github.com/user-attachments/assets/25ce32c4-f97c-419e-993e-64f90fefbf4d)
![Reconfigure](https://github.com/user-attachments/assets/b2f926eb-e60e-43b7-a430-ff47637bcdf7)
![Repair success](https://github.com/user-attachments/assets/c02c55fb-9d75-4a56-950b-219da0e0607f)

### Client Changes:

* Introduced `extract_ids_from_share_url` to extract `user_id` and `pool_id` from a `share_url` via API calls.
* Updated the API endpoint in `client.py` to use the new `share/pool` path for fetching pool data. Note that without the `/pool` string in the URL, it would 404.

### Configuration and Translations:

* Added constants `CONF_SHARE_ID` back, and `CONF_SHARE_URL` for handling legacy and new configuration formats. These can be removed down the road.
* Updated `strings.json` and `translations/en.json` to include user-facing messages for the repair flow, including error handling and instructions for providing a `share_url`. [[1]](diffhunk://#diff-859b049a2607bb7716c3e9dd5f9c5e9d72298b5037b6294b237aa4c934353286R24-R49) [[2]](diffhunk://#diff-3152a69f4213c0dff28d18730e9897653bba2b7747d635138ed3086a3fd69860R36-R62)

Let me know if this PR is too big.