### PR TITLE
Migrate deprecated async_forward_entry_setup usage

### DIFF
--- a/custom_components/poolmath/__init__.py
+++ b/custom_components/poolmath/__init__.py
@@ -55,7 +55,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
     # forward entry setup to platform(s)
-    await hass.config_entries.async_forward_entry_setup(entry, Platform.SENSOR)
+    await hass.config_entries.async_forward_entry_setups(entry, [Platform.SENSOR])
 
     return True
 


### PR DESCRIPTION
Resolves the following warning:

> Detected that custom integration 'poolmath' calls async_forward_entry_setup for integration, poolmath with title: Pool Math and entry_id: **redacted**, which is deprecated, await async_forward_entry_setups instead at custom_components/poolmath/__init__.py, line 58: await hass.config_entries.async_forward_entry_setup(entry, Platform.SENSOR). This will stop working in Home Assistant 2025.6.

Since we're close to the 2025.6 release, I figure we should ensure this gets included in the 2.0.0 release.

Here's a link to the HA developer blog noting the deprecation: https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/

The main difference is that the 2nd parameter accepts an array of platforms now.

Tested and confirmed the warning is no longer logged after a restart.