### PR TITLE
Simplify Installation process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 __pycache__
 install
 
+.venv/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,15 +8,6 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-
-  # isort - sort import statements
-  - repo: https://github.com/pycqa/isort
-    rev: 6.0.0
-    hooks:
-      - id: isort
-        files: \.(py)$
-        args: [--settings-path=pyproject.toml]  # ["--profile", "black" ]
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.3
     hooks:

--- a/README.md
+++ b/README.md
@@ -50,19 +50,13 @@ Make sure [Home Assistant Community Store (HACS)](https://github.com/custom-comp
 
 ### Configuration
 
-Under Settings of the Pool Math iOS or Android application, find the Sharing section.  Turn this on (and be sure to save the changes too), which allows anyone with access to the unique URL to be able to view data about your pool. Your pool's URL will be displayed.  You will need this URL to determine your `userId` and `poolId` configuration values for this component.
+Under Settings of the Pool Math iOS or Android application, find the Sharing section. Turn this on (and be sure to save the changes too), which allows anyone with access to the unique URL to be able to view data about your pool. Your pool's URL will be displayed, which you'll need for setting up this integration.
 
-Take the generated URL and modify it to add `.json` to the end of it.  Enter the URL in your browser or curl or some client to see the JSON output.  
-
-Example URL: `https://troublefreepool.com/mypool/7WPG8yL.json`
-
-From the JSON output, you will need to find the values for the `id` and `userId` properties.  Your userId will start with `tfp-` if you are using a TroubleFreePool forum account in the app, or `google-` / `facebook-` / `apple-` if you use those sign in providers.  Your `id` (poolId) will be a longer GUID string.
-
-Configure `Pool Math (Trouble Free Pool)` via integrations page or press the blue button below, filling in the `userId` and `poolId` you determined from the JSON.
+Configure `Pool Math (Trouble Free Pool)` via integrations page or press the blue button below, and enter your Pool Math share URL:
 
 [![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=poolmath)
 
-NOTE: This updates the state from PoolMath every 8 minutes (results are cached for 10 minutes already, and requests are rate limited to no more than once per minute) to keep from overwhelming their service, as the majority of Pool Math users update their data manual after testing rather than automated. The check interval can be changed in yaml config by adding a 'scan_interval' for the sensor.
+NOTE: This updates the state from PoolMath every 8 minutes (results are cached for 10 minutes already, and requests are rate limited to no more than once per minute) to keep from overwhelming their service, as the majority of Pool Math users update their data manual after testing rather than automated. The check interval can be changed in the configuration options.
 
 ### Example Lovelace UI
 

--- a/custom_components/poolmath/config_flow.py
+++ b/custom_components/poolmath/config_flow.py
@@ -1,28 +1,22 @@
 """Config flow for Pool Math integration."""
 
 import logging
-from typing import Any, Union
+from typing import Any
 
 import voluptuous as vol
-
-from homeassistant.config_entries import (
-    ConfigEntry,
-    ConfigFlow,
-    OptionsFlow,
-)
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_NAME, CONF_SCAN_INTERVAL
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv
 
 from .const import (
-    CONF_USER_ID,
     CONF_POOL_ID,
+    CONF_SHARE_URL,
     CONF_TARGET,
-    CONF_TIMEOUT,
+    CONF_USER_ID,
     DEFAULT_NAME,
     DEFAULT_TARGET,
-    DEFAULT_TIMEOUT,
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
     INTEGRATION_NAME,
@@ -30,61 +24,149 @@ from .const import (
 
 LOG = logging.getLogger(__name__)
 
+# Define targets as a constant instead of a function for cleaner code
+TARGET_OPTIONS = vol.All(
+    vol.In(
+        {
+            'tfp': 'Trouble Free Pools',
+            'bioguard': 'Bio Guard',
+            'robert_lowry': 'Robert Lowry',
+        }
+    )
+)
 
-def _initial_form(flow: Union[ConfigFlow, OptionsFlow]):
-    """Return flow form for init/user step id."""
 
-    if isinstance(flow, ConfigFlow):
-        step_id = "user"
-    else:
-        step_id = "init"
-
-    options = {} # empty in case of isinstance ConfigFlow
-    if isinstance(flow, OptionsFlow):
-        options = flow.config_entry.options
-
-    # from https://api.poolmathapp.com/share/?userId=[USER_ID]&poolId=[POOL_ID]
-    user_id = options.get(CONF_USER_ID)
-    pool_id = options.get(CONF_POOL_ID)
-    name = options.get(CONF_NAME, DEFAULT_NAME)
-    timeout = options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
-    target = options.get(CONF_TARGET, DEFAULT_TARGET)
-    scan_interval = options.get(CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL)
-
-    # FIXME:
-    # What is the best customer experience here? Is it actually taking user_id and pool_id
-    # since that seems hard to find in Pool Math app and online web portal when using the
-    # share URL. Or is it better to just take share URL and then extract these user/pool ids
-    # from the data returned?  Let's make this EASY on users with minimal technical understanding.
-
-    return flow.async_show_form(
-        step_id=step_id,  # parameterized to follow guidance on using "user"
-        data_schema=vol.Schema({
-            vol.Required(CONF_USER_ID, default=user_id): cv.string,
-            vol.Required(CONF_POOL_ID, default=pool_id): cv.string,
-            vol.Optional(CONF_NAME, default=name): cv.string,
+def _build_share_url_schema(share_url=None, name=None, target=None, scan_interval=None):
+    """Build the data schema for share URL configuration."""
+    return vol.Schema(
+        {
+            vol.Required(CONF_SHARE_URL, default=share_url): cv.string,
+            vol.Optional(CONF_NAME, default=name or DEFAULT_NAME): cv.string,
             # NOTE: targets are not really implemented, other than tfp
-            vol.Optional(CONF_TARGET, default="tfp"): vol.All(
-                vol.In({
-                    "tfp": "Trouble Free Pools",
-                    "bioguard": "Bio Guard",
-                    "robert_lowry": "Robert Lowry"
-                })
+            vol.Optional(CONF_TARGET, default=target or DEFAULT_TARGET): TARGET_OPTIONS,
+            vol.Optional(
+                CONF_SCAN_INTERVAL, default=scan_interval or DEFAULT_UPDATE_INTERVAL
+            ): cv.positive_int,
+        }
+    )
+
+
+async def _process_share_url(
+    flow, step_id: str, share_url: str, user_input: dict
+) -> FlowResult:
+    """Process a share URL and extract user_id and pool_id.
+
+    Args:
+        flow: The flow instance (ConfigFlow or OptionsFlow)
+        step_id: The step ID for showing forms
+        share_url: The Pool Math share URL
+        user_input: The user input data containing form values
+
+    Returns:
+        A FlowResult with either an error form or the extracted IDs
+    """
+    from .client import PoolMathClient
+
+    try:
+        user_id, pool_id = await PoolMathClient.extract_ids_from_share_url(share_url)
+
+        if not user_id or not pool_id:
+            return flow.async_show_form(
+                step_id=step_id,
+                data_schema=_build_share_url_schema(
+                    share_url=share_url,
+                    name=user_input.get(CONF_NAME, DEFAULT_NAME),
+                    target=user_input.get(CONF_TARGET, DEFAULT_TARGET),
+                    scan_interval=user_input.get(
+                        CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL
+                    ),
+                ),
+                errors={'base': 'invalid_share_url'},
+            )
+
+        # Return the extracted IDs along with other options
+        return {
+            CONF_USER_ID: user_id,
+            CONF_POOL_ID: pool_id,
+            CONF_NAME: user_input.get(CONF_NAME, DEFAULT_NAME),
+            CONF_TARGET: user_input.get(CONF_TARGET, DEFAULT_TARGET),
+            CONF_SCAN_INTERVAL: user_input.get(
+                CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL
             ),
-            vol.Optional(CONF_SCAN_INTERVAL, default=scan_interval): cv.positive_int,
-        })
+        }
+
+    except Exception as exc:
+        LOG.exception(f'Error processing Pool Math share URL: {exc}')
+        return flow.async_show_form(
+            step_id=step_id,
+            data_schema=_build_share_url_schema(
+                share_url=share_url,
+                name=user_input.get(CONF_NAME, DEFAULT_NAME),
+                target=user_input.get(CONF_TARGET, DEFAULT_TARGET),
+                scan_interval=user_input.get(
+                    CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL
+                ),
+            ),
+            errors={'base': 'unknown_error'},
+        )
+
+
+def _initial_form(flow: ConfigFlow | OptionsFlow):
+    """Return flow form for init/user step id."""
+    # Determine the step ID based on flow type
+    step_id = 'user' if isinstance(flow, ConfigFlow) else 'init'
+
+    # Default values
+    name = DEFAULT_NAME
+    target = DEFAULT_TARGET
+    scan_interval = DEFAULT_UPDATE_INTERVAL
+
+    # Get current values from options if available
+    if isinstance(flow, OptionsFlow) and hasattr(flow, 'config_entry'):
+        options = flow.config_entry.options
+        name = options.get(CONF_NAME, DEFAULT_NAME)
+        target = options.get(CONF_TARGET, DEFAULT_TARGET)
+        scan_interval = options.get(CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL)
+
+    # Return the form with the share URL schema
+    return flow.async_show_form(
+        step_id=step_id,
+        data_schema=_build_share_url_schema(
+            share_url=None, name=name, target=target, scan_interval=scan_interval
+        ),
     )
 
 
 class PoolMathOptionsFlow(OptionsFlow):
     """Handle Pool Math options."""
-    
+
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Manage Pool Math options."""
         if user_input is not None:
-            return self.async_create_entry(title=INTEGRATION_NAME, data=user_input)
+            share_url = user_input.get(CONF_SHARE_URL)
+
+            # If share URL is provided, extract user_id and pool_id
+            if share_url:
+                result = await _process_share_url(self, 'init', share_url, user_input)
+
+                # If result is a dictionary (not a form), it contains the extracted data
+                if isinstance(result, dict):
+                    return self.async_create_entry(title=INTEGRATION_NAME, data=result)
+                return result
+            else:
+                # No share URL provided, just update the other options
+                options = {
+                    CONF_USER_ID: self.config_entry.data.get(CONF_USER_ID),
+                    CONF_POOL_ID: self.config_entry.data.get(CONF_POOL_ID),
+                    CONF_NAME: user_input.get(CONF_NAME, DEFAULT_NAME),
+                    CONF_TARGET: user_input.get(CONF_TARGET, DEFAULT_TARGET),
+                    CONF_SCAN_INTERVAL: user_input.get(
+                        CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL
+                    ),
+                }
+                return self.async_create_entry(title=INTEGRATION_NAME, data=options)
 
         return _initial_form(self)
 
@@ -94,14 +176,39 @@ class PoolMathFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None) -> FlowResult:
         """Handle the initial step."""
-        if user_input is not None:
-            user_id = user_input.get(CONF_USER_ID)
-            pool_id = user_input.get(CONF_POOL_ID)
-            
-            await self.async_set_unique_id(f"{user_id}-{pool_id}")
-            self._abort_if_unique_id_configured()
 
-            return self.async_create_entry(title=INTEGRATION_NAME, data=user_input)
+        if user_input is not None:
+            share_url = user_input.get(CONF_SHARE_URL)
+
+            # Extract user_id and pool_id from the share URL
+            try:
+                result = await _process_share_url(self, 'user', share_url, user_input)
+
+                # If result is a dictionary (not a form), it contains the extracted data
+                if isinstance(result, dict):
+                    user_id = result[CONF_USER_ID]
+                    pool_id = result[CONF_POOL_ID]
+
+                    await self.async_set_unique_id(f'{user_id}-{pool_id}')
+                    self._abort_if_unique_id_configured()
+
+                    return self.async_create_entry(title=INTEGRATION_NAME, data=result)
+                return result
+
+            except Exception as exc:
+                LOG.exception(f'Error processing Pool Math share URL: {exc}')
+                return self.async_show_form(
+                    step_id='user',
+                    data_schema=_build_share_url_schema(
+                        share_url=share_url,
+                        name=user_input.get(CONF_NAME, DEFAULT_NAME),
+                        target=user_input.get(CONF_TARGET, DEFAULT_TARGET),
+                        scan_interval=user_input.get(
+                            CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL
+                        ),
+                    ),
+                    errors={'base': 'unknown_error'},
+                )
 
         return _initial_form(self)
 
@@ -111,11 +218,11 @@ class PoolMathFlowHandler(ConfigFlow, domain=DOMAIN):
         config_entry: ConfigEntry,
     ) -> PoolMathOptionsFlow:
         """Get the options flow for this handler."""
-        
-        # Maintain compatibility with Home Assistant's options flow 
-        # system while adapting to the new pattern where the constructor 
-        # doesn't take config_entry. The config_entry is still available 
-        # to the options flow through self.config_entry, but we're now 
+
+        # Maintain compatibility with Home Assistant's options flow
+        # system while adapting to the new pattern where the constructor
+        # doesn't take config_entry. The config_entry is still available
+        # to the options flow through self.config_entry, but we're now
         # setting it as an attribute rather than passing it through the constructor.
         flow = PoolMathOptionsFlow()
         flow.config_entry = config_entry

--- a/custom_components/poolmath/strings.json
+++ b/custom_components/poolmath/strings.json
@@ -4,10 +4,8 @@
       "user": {
         "description": "Connect to Pool Math",
         "data": {
-          "user_id": "[%key:common::config_flow::data::user_id%]",
-          "pool_id": "[%key:common::config_flow::data::pool_id%]",
+          "share_url": "Pool Math Share URL",
           "name": "[%key:common::config_flow::data::name%]",
-          "timeout": "[%key:common::config_flow::data::timeout%]",
           "target": "[%key:common::config_flow::data::target%]",
           "scan_interval": "How often to check for pool data updates (in minutes)"
         }
@@ -16,6 +14,8 @@
     "error": {
       "cannot_connect": "Failed to connect, please try again",
       "invalid_auth": "Invalid authentication",
+      "invalid_share_url": "Invalid Pool Math share URL or could not extract pool information from it",
+      "unknown_error": "Unexpected error processing the share URL",
       "unknown": "Unexpected error"
     },
     "abort": {
@@ -52,13 +52,16 @@
     "step": {
       "init": {
         "data": {
-          "user_id": "[%key:common::config_flow::data::user_id%]",
-          "pool_id": "[%key:common::config_flow::data::pool_id%]",
+          "share_url": "Pool Math Share URL",
           "name": "[%key:common::config_flow::data::name%]",
-          "timeout": "[%key:common::config_flow::data::timeout%]",
-          "target": "[%key:common::config_flow::data::target%]"
+          "target": "[%key:common::config_flow::data::target%]",
+          "scan_interval": "How often to check for pool data updates (in minutes)"
         }
       }
+    },
+    "error": {
+      "invalid_share_url": "Invalid Pool Math share URL or could not extract pool information from it",
+      "unknown_error": "Unexpected error processing the share URL"
     }
   }
 }

--- a/custom_components/poolmath/translations/en.json
+++ b/custom_components/poolmath/translations/en.json
@@ -4,10 +4,8 @@
       "user": {
         "description": "Connect to Pool Math",
         "data": {
-          "user_id": "User ID from PoolMath share URL JSON version (e.g. api.poolmathapp.com/share/?userId=XXX)",
-          "pool_id": "Pool ID from PoolMath share URL JSON version (to find pool ID, call /share/pool?userId=YOURID)",
+          "share_url": "Pool Math Share URL from the Pool Math app (Settings > Sharing)",
           "name": "Pool Name",
-          "timeout": "Update timeout",
           "target": "Target levels source",
           "scan_interval": "How often to check for pool data updates (in minutes)"
         }
@@ -16,6 +14,8 @@
     "error": {
       "cannot_connect": "Failed to connect, please try again",
       "invalid_auth": "Invalid authentication",
+      "invalid_share_url": "The provided URL is not a valid Pool Math share URL or we could not extract the pool information from it.",
+      "unknown_error": "An unexpected error occurred while processing the share URL. Please check the logs for more details.",
       "unknown": "Unexpected error"
     },
     "abort": {
@@ -26,14 +26,16 @@
     "step": {
       "init": {
         "data": {
-          "user_id": "User ID from PoolMath share URL JSON version (e.g. https:api.poolmathapp.com/share/?userId=XXX)",
-          "pool_id": "Pool ID from PoolMath share URL JSON version (to find pool ID, call /share/pool?userId=YOURID)",
+          "share_url": "Pool Math Share URL from the Pool Math app (Settings > Sharing)",
           "name": "Pool Name",
-          "timeout": "Update timeout",
           "target": "Target levels source",
           "scan_interval": "Update interval (minutes; default=8) - please avoid setting lower to protect Pool Math servers"
         }
       }
+    },
+    "error": {
+      "invalid_share_url": "The provided URL is not a valid Pool Math share URL or we could not extract the pool information from it.",
+      "unknown_error": "An unexpected error occurred while processing the share URL. Please check the logs for more details."
     }
   },
   "issues": {
@@ -46,7 +48,7 @@
             "title": "Update Pool Math Configuration",
             "description": "Please paste your Pool Math share URL from the Pool Math app. You can find this under Settings > Sharing. The URL should look like: https://api.poolmathapp.com/share/XXXXXXX or https://troublefreepool.com/mypool/XXXXXXX.",
             "data": {
-              "share_url": "Pool Math Share URL"
+              "share_url": "Pool Math Share URL from the Pool Math app (Settings > Sharing)"
             }
           }
         },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,16 @@ lint.ignore = [
        "F405"  # * imports
 ]
 
+# Import sorting settings (replaces isort)
+[tool.ruff.lint.isort]
+force-single-line = false
+force-sort-within-sections = true
+known-first-party = ["custom_components"]
+section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
+combine-as-imports = true
+known-first-party-from-imports = true
+force-to-top = ["logging"]
+
 [tool.ruff.format]
 quote-style = "single" # Use a single quote instead of double
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ force-sort-within-sections = true
 known-first-party = ["custom_components"]
 section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
 combine-as-imports = true
-known-first-party-from-imports = true
 force-to-top = ["logging"]
 
 [tool.ruff.format]


### PR DESCRIPTION
This PR streamlines the configuration process. The key change includes `userId` and `poolId` with the simplified share URL input (similar to the repair flow), and refactoring the configuration flow code.

I also removed the `isort` dependency in favor of Ruff-based import sorting. Once I installed the pre-commit hooks, `isort` and `ruff` kept fighting over style and preventing commits.

These are some big changes (at least LoC-wise), and I still need to test a reinstall on my HA instance - so use with caution or not at all. 😅

Since there are other modernization efforts going on, feel free to improve upon this or just salvage useful bits.

### Pool Math integration improvements:

* Updated the configuration process to use a single Pool Math share URL instead of requiring users to manually extract `userId` and `poolId`. This simplifies the setup and improves user experience.

* Updated error handling for invalid or unexpected share URLs, with clear error messages added to both the UI and logs.

### Documentation updates:

* Simplified the README instructions to reflect the new share URL-based configuration process, removing steps for manually extracting `userId` and `poolId`. (`README.md`)

### Codebase cleanup and configuration:

* Removed the `isort` dependency from the pre-commit configuration and replaced it with Ruff-based import sorting settings in `pyproject.toml`. 