### PR TITLE
Notify Home Assistant that the sensor state has changed

### DIFF
--- a/custom_components/poolmath/sensor.py
+++ b/custom_components/poolmath/sensor.py
@@ -438,6 +438,9 @@ class UpdatableSensor(RestoreSensor, SensorEntity):
 
         await self.update_sensor_targets()
 
+        # Notify Home Assistant that the sensor state has changed
+        self.async_write_ha_state()
+
     async def update_sensor_targets(self) -> None:
         """
         Update attributes for the sensor to include targets if


### PR DESCRIPTION
Added `self.async_write_ha_state()` at the end of the `inject_state` method in the `UpdatableSensor` class.

If I understand correctly, the process is:
1. Coordinator fetches new data.
2. `PoolMathServiceSensorgets._handle_coordinator_update` called.
3. Individual sensors get their state updated via `inject_state()`.
4. Sensors call `self.async_write_ha_state()` to notify HA.
5. Sensors show current values in HA UI

It appears to work well!